### PR TITLE
refactor: add defer keyword for loading htmx

### DIFF
--- a/source/template/dashboard.html
+++ b/source/template/dashboard.html
@@ -10,7 +10,7 @@
   <link rel="icon" type="image/x-icon" href="static/favicon.png">
   <link href="static/twcolors.min.css" rel="stylesheet">
   <link href="static/styles.css" rel="stylesheet">
-  <script src="static/htmx.min.js"></script>
+  <script src="static/htmx.min.js" defer></script>
 </head>
 
 <body id="body">

--- a/source/template/index.html
+++ b/source/template/index.html
@@ -9,7 +9,7 @@
     content="A command line tool that helps you build and test web app ideas blazingly-fast with a streamlined Go, HTMX, and SQLite stack. Authored by Damien Sedgwick.">
   <link href="static/twcolors.min.css" rel="stylesheet">
   <link href="static/styles.css" rel="stylesheet">
-  <script src="static/htmx.min.js"></script>
+  <script src="static/htmx.min.js" defer></script>
 </head>
 
 <body id="body">


### PR DESCRIPTION
Why: With defer keyword, we make sure to parse the whole page and render before running htmx. Refer this [post](https://www.reddit.com/r/htmx/comments/1cao397/remember_to_add_defer_to_script_in_head/).

How: By adding a defer keyword in `script` tag.

Tags: [htmx, defer]